### PR TITLE
PEP-561

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -4,6 +4,7 @@ Changelog and release history
 ## latest
 
  - Fix timezone usage inconsistencies.
+ - Make a package PEP-561 compliant.
 
 ## [1.2.1](https://pypi.org/project/sonyflake-py/1.2.1/) (2021-03-20)
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         url="https://github.com/hjpotter92/sonyflake-py",
         packages=find_packages(),
+        package_data={"sonyflake": ["py.typed"]},
         include_package_data=True,
         classifiers=[
             "Development Status :: 5 - Production/Stable",

--- a/sonyflake/__init__.py
+++ b/sonyflake/__init__.py
@@ -1,2 +1,4 @@
 from .about import NAME, VERSION, __version__
 from .sonyflake import SonyFlake
+
+__all__ = ["SonyFlake"]

--- a/sonyflake/sonyflake.py
+++ b/sonyflake/sonyflake.py
@@ -26,6 +26,9 @@ class SonyFlake:
     The distributed unique ID generator.
     """
 
+    _start_time: int
+    _machine_id: int
+
     def __new__(
         cls,
         start_time: Optional[datetime.datetime] = None,
@@ -49,7 +52,7 @@ class SonyFlake:
         start_time: Optional[datetime.datetime] = None,
         machine_id: Optional[Callable[[], int]] = None,
         check_machine_id: Optional[Callable[[int], bool]] = None,
-    ):
+    ) -> None:
         """
         Create a new instance of `SonyFlake` unique ID generator.
 
@@ -96,27 +99,27 @@ class SonyFlake:
         return int(given_time.timestamp() * 100)
 
     @property
-    def start_time(self):
+    def start_time(self) -> int:
         return self._start_time
 
     @property
-    def machine_id(self):
+    def machine_id(self) -> int:
         return self._machine_id
 
-    def current_time(self):
+    def current_time(self) -> int:
         """
         Get current UTC time in the SonyFlake's time value.
         """
         return self.to_sonyflake_time(datetime.datetime.now(UTC))
 
-    def current_elapsed_time(self):
+    def current_elapsed_time(self) -> int:
         """
         Get time elapsed since the SonyFlake ID generator was
         initialised.
         """
         return self.current_time() - self.start_time
 
-    def next_id(self):
+    def next_id(self) -> int:
         """
         Generates and returns the next unique ID.
 


### PR DESCRIPTION
Make a package PEP-561 compliant.

Omitted adding return type for `__new__`, since mypy is not fond of `__new__` returning something other than class instance. In a long-term I think it would be better to throw an exception instead of returning `None`, Python is not Go after all.