### PR TITLE
Improve machine_id ergonomics

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Black Check
-        uses: jpetrucciani/black-check@20.8b1
+        uses: jpetrucciani/black-check@24.8.0
       - name: python-isort
-        uses: isort/isort-action@v0.1.0
+        uses: isort/isort-action@v1
         with:
-          isortVersion: 5.7.0
+          isort-version: 5.13.2
           configuration: --profile black --diff --check-only

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The generator can be configured with variety of options, such as
 custom `machine_id`, `start_time` etc.
 
 - `start_time` should be an instance of `datetime.datetime`.
-- `machine_id` should be a callable which returns an integer value
-  upto 16-bits.
+- `machine_id` should be an integer value upto 16-bits, callable or
+  `None` (will be used random machine id).
 
 ## License
 

--- a/sonyflake/sonyflake.py
+++ b/sonyflake/sonyflake.py
@@ -1,22 +1,29 @@
 import datetime
 import ipaddress
+from functools import partial
+from random import randrange
 from socket import gethostbyname, gethostname
 from threading import Lock
 from time import sleep
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union
+from warnings import warn
 
 BIT_LEN_TIME = 39
 BIT_LEN_SEQUENCE = 8
 BIT_LEN_MACHINE_ID = 63 - (BIT_LEN_TIME + BIT_LEN_SEQUENCE)
+MAX_MACHINE_ID = (1 << BIT_LEN_MACHINE_ID) - 1
 UTC = datetime.timezone.utc
 SONYFLAKE_EPOCH = datetime.datetime(2014, 9, 1, 0, 0, 0, tzinfo=UTC)
+random_machine_id = partial(randrange, 0, MAX_MACHINE_ID + 1)
+random_machine_id.__doc__ = "Returns a random machine ID."
+utc_now = partial(datetime.datetime.now, tz=UTC)
 
 
 def lower_16bit_private_ip() -> int:
     """
     Returns the lower 16 bits of the private IP address.
     """
-    ip: ipaddress.IPv4Address = ipaddress.ip_address(gethostbyname(gethostname()))
+    ip = ipaddress.ip_address(gethostbyname(gethostname()))
     ip_bytes = ip.packed
     return (ip_bytes[2] << 8) + ip_bytes[3]
 
@@ -29,29 +36,21 @@ class SonyFlake:
     _start_time: int
     _machine_id: int
 
-    def __new__(
-        cls,
-        start_time: Optional[datetime.datetime] = None,
-        machine_id: Optional[Callable[[], int]] = None,
-        check_machine_id: Optional[Callable[[int], bool]] = None,
-    ):
-        if start_time and datetime.datetime.now(UTC) < start_time:
-            return None
-        instance = super().__new__(cls)
-        if machine_id is not None:
-            instance._machine_id = machine_id()
-        else:
-            instance._machine_id = lower_16bit_private_ip()
-        if check_machine_id is not None:
-            if not check_machine_id(instance._machine_id):
-                return None
-        return instance
+    __slots__ = (
+        "_now",
+        "mutex",
+        "_start_time",
+        "_machine_id",
+        "elapsed_time",
+        "sequence",
+    )
 
     def __init__(
         self,
         start_time: Optional[datetime.datetime] = None,
-        machine_id: Optional[Callable[[], int]] = None,
-        check_machine_id: Optional[Callable[[int], bool]] = None,
+        machine_id: Union[None, int, Callable[[], int]] = None,
+        check_machine_id: Any = None,
+        now: Callable[[], datetime.datetime] = utc_now,
     ) -> None:
         """
         Create a new instance of `SonyFlake` unique ID generator.
@@ -65,30 +64,40 @@ class SonyFlake:
         * If `start_time` is ahead of the current time, SonyFlake is
         not created.
 
-        `machine_id` returns the unique ID of the SonyFlake instance.
+        `machine_id` a unique ID of the SonyFlake instance in range [0x0000, 0xFFFF].
 
-        * If `machine_id` returns an error, SonyFlake is not created.
+        * If `machine_id` is an integer, it is used as is.
 
-        * If `machine_id` is nil, default `machine_id` is used.
+        * If `machine_id` is a callable, it is called to get the machine ID.
 
-        * Default `machine_id` returns the lower 16 bits of the
-        private IP address.
-
-        `check_machine_id` validates the uniqueness of the machine ID.
-
-        * If `check_machine_id` returns `False`, SonyFlake is not
-        created.
-
-        * If `check_machine_id` is `None`, no validation is done.
+        * Otherwise, a random machine ID is generated.
         """
+
         if start_time is None:
             start_time = SONYFLAKE_EPOCH
+
+        if now() < start_time:
+            raise ValueError("start_time cannot be in future")
+
+        if machine_id is None:
+            _machine_id = random_machine_id()
+        elif callable(machine_id):
+            _machine_id = machine_id()
+        else:
+            _machine_id = machine_id
+
+        if not (0 <= _machine_id <= MAX_MACHINE_ID):
+            raise ValueError("machine_id must be in range [0x0000, 0xFFFF]")
+
+        if check_machine_id is not None:
+            warn("check_machine_id is deprecated", DeprecationWarning)
+
         self.mutex = Lock()
+        self._now = now
+        self._machine_id = _machine_id
         self._start_time = self.to_sonyflake_time(start_time)
         self.elapsed_time = self.current_elapsed_time()
         self.sequence = (1 << BIT_LEN_SEQUENCE) - 1
-        if not hasattr(self, "_machine_id"):
-            self._machine_id = machine_id and machine_id() or lower_16bit_private_ip()
 
     @staticmethod
     def to_sonyflake_time(given_time: datetime.datetime) -> int:
@@ -110,7 +119,7 @@ class SonyFlake:
         """
         Get current UTC time in the SonyFlake's time value.
         """
-        return self.to_sonyflake_time(datetime.datetime.now(UTC))
+        return self.to_sonyflake_time(self._now())
 
     def current_elapsed_time(self) -> int:
         """
@@ -136,7 +145,7 @@ class SonyFlake:
                 if self.sequence == 0:
                     self.elapsed_time += 1
                     overtime = self.elapsed_time - current_time
-                    sleep(self.sleep_time(overtime))
+                    sleep(self.sleep_time(overtime, self._now()))
             return self.to_id()
 
     def to_id(self) -> int:
@@ -147,13 +156,11 @@ class SonyFlake:
         return time | sequence | self.machine_id
 
     @staticmethod
-    def sleep_time(duration: int) -> float:
+    def sleep_time(duration: int, now: datetime.datetime) -> float:
         """
         Calculate the time remaining until generation of new ID.
         """
-        return (
-            duration * 10 - (datetime.datetime.now(UTC).timestamp() * 100) % 1
-        ) / 100
+        return (duration * 10 - (now.timestamp() * 100) % 1) / 100
 
     @staticmethod
     def decompose(_id: int) -> Dict[str, int]:


### PR DESCRIPTION
I'm successfully using this library in production for a quite a while, but API around machine ids caused me some degree of discomfort. This PR fixes #8 as well as some improvements:

* Generating a lot of (millions) of ids efficiently is possible with multiple SonyFlake instances. Using callbacks to pass constant ids is counter-intuitive and not as performant. In this case you want to pre-generate set of random machine ids and iterate over list of id generators.
* Issue #8 mentions Celery, but the problem is much more general. If several id generators share the same IP, issue would re-appear. To some extent it can be mitigated by using random machine ids. On somehow related note, [new UUID standard](https://www.rfc-editor.org/rfc/rfc9562.html) no longer recommends using non-random node ids which is essentially has the same role as `machine_id` in SonyFlake.
* Removed `__new__` method, since it does not make sense. If some input params are invalid, `None` would be unpleasant surprise to encounter. Better be explicit and raise an error.
* Add option to pass `now` callback, for test reproducibility.

Overall, public API should be more-or-less backward compatible.